### PR TITLE
Fix Spotify API base URL usage in tests

### DIFF
--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -26,7 +26,7 @@ export const test = base.extend<ApiFixtures>({
     
     // Create authenticated API request context using playwright.request
     const api = await playwright.request.newContext({
-      baseURL: 'https://api.spotify.com/v1',  // Set Spotify API base URL
+      baseURL: 'https://api.spotify.com/v1/',  // Set Spotify API base URL
       extraHTTPHeaders: { Authorization: `Bearer ${token}` },  // Add auth header
     });
     

--- a/tests/me.spec.ts
+++ b/tests/me.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
 test('get current user profile', async ({ api }) => {
-  const res = await api.get('/me');
+  const res = await api.get('me');
   expect(res.status()).toBe(200);
   const json = await res.json();
   expect(json).toHaveProperty('id');

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
 test('search tracks', async ({ api }) => {
-  const res = await api.get('/search', { params: { q: 'Radiohead', type: 'track', limit: 5 } });
+  const res = await api.get('search', { params: { q: 'Radiohead', type: 'track', limit: 5 } });
   expect(res.status()).toBe(200);
   const data = await res.json();
   expect(data.tracks.items.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- ensure the Playwright API context uses a Spotify base URL with a trailing slash
- remove leading slashes from API request paths in the Spotify tests so they concatenate correctly

## Testing
- npx playwright test tests/search.spec.ts tests/me.spec.ts *(fails: FetchError to accounts.spotify.com due to missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d8838d706c832c9731d516b6ba5b00