### PR TITLE
Skip /me test without refresh token

### DIFF
--- a/tests/me.spec.ts
+++ b/tests/me.spec.ts
@@ -1,9 +1,13 @@
 import { test, expect } from './fixtures';
 
-test('get current user profile', async ({ api }) => {
-  const res = await api.get('me');
-  expect(res.status()).toBe(200);
-  const json = await res.json();
-  expect(json).toHaveProperty('id');
-  expect(json).toHaveProperty('email'); // if scope granted
+test.describe('current user profile', () => {
+  test.skip(!process.env.SPOTIFY_REFRESH_TOKEN, 'SPOTIFY_REFRESH_TOKEN env var required for /me endpoint');
+
+  test('get current user profile', async ({ api }) => {
+    const res = await api.get('me');
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    expect(json).toHaveProperty('id');
+    expect(json).toHaveProperty('email'); // if scope granted
+  });
 });


### PR DESCRIPTION
## Summary
- skip the current user profile API test when a refresh token is not configured
- document the requirement directly in the test to prevent 401 responses when using client-credentials auth

## Testing
- npx playwright test tests/me.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d887d604c0832cb434acbddc50f1f4